### PR TITLE
Prevent compiler warnings

### DIFF
--- a/psm_context.c
+++ b/psm_context.c
@@ -381,7 +381,7 @@ psmi_context_check_status(const psmi_context_t *contexti)
 		else
 		    errmsg = "Hardware not found";
 
-		psmi_handle_error(context->ep, err, errmsg);
+		psmi_handle_error(context->ep, err, errmsg, "%s");
 	    }
 	}
     }

--- a/psm_diags.c
+++ b/psm_diags.c
@@ -244,6 +244,7 @@ void *memcpy_check_one (memcpy_fn_t fn, void *dst, void *src, size_t n)
 	  ((uintptr_t) dst ^ (uintptr_t) src ^ (uintptr_t) n);
   unsigned int state;
   size_t i;
+  psmi_assert_always(n > 0);
   memset(src, 0x55, n);
   memset(dst, 0xaa, n);
   srand(seed);

--- a/psm_ep_connect.c
+++ b/psm_ep_connect.c
@@ -275,7 +275,7 @@ connect_fail:
 	    }
 	}
 	errbuf[sizeof errbuf - 1] = '\0';
-	err = psmi_handle_error(ep, err, errbuf);
+	err = psmi_handle_error(ep, err, errbuf, "%s");
     }
 
 fail:

--- a/psm_utils.c
+++ b/psm_utils.c
@@ -1202,7 +1202,7 @@ psmi_coreopt_ctl(const void *core_obj, int optname,
   
  fail:
   /* Unrecognized/unknown option */
-  return psmi_handle_error(NULL, PSM_PARAM_ERR, err_string);
+  return psmi_handle_error(NULL, PSM_PARAM_ERR, err_string, "%s");
 }
 
 psm_error_t psmi_core_setopt(const void *core_obj, int optname, 


### PR DESCRIPTION
* Commit 1428766bfad94be648258f13e5c4c29a27a2bd38:
```
psm_context.c: In function ‘psmi_context_check_status’:                            
psm_context.c:384:3: error: format not a string literal and no format arguments [-Werror=format-security]                                                             
   psmi_handle_error(context->ep, err, errmsg);
```
* Commit f61b3427c9d52d7e63181ca8dbb1a37ac60f0433:
```
In function ‘memset’,                                                              
    inlined from ‘memcpy_check_one.constprop.4’ at psm_diags.c:248:9,              
    inlined from ‘memcpy_check_size.constprop.2’ at psm_diags.c:303:33,            
    inlined from ‘psmi_test_memcpy.constprop.1’ at psm_diags.c:201:9,              
    inlined from ‘psmi_diags’ at psm_diags.c:64:28:                                
/usr/include/x86_64-linux-gnu/bits/string3.h:81:30: error: call to ‘__warn_memset_zero_len’ declared with attribute warning: memset used with constant zero length parameter; this could be due to transposed parameters [-Werror]                       
       __warn_memset_zero_len ();
```