### PR TITLE
Initialize variables

### DIFF
--- a/psm.h
+++ b/psm.h
@@ -275,7 +275,7 @@ typedef struct psm_error_token	*psm_error_token_t;
  * individually set for each opened endpoint.  By default, endpoints will
  * inherit the global handler registered at the time of open. 
  *
- * [in] ep Handle associated to the endpoint over which the error occured
+ * [in] ep Handle associated to the endpoint over which the error occurred
  *               or NULL if the error is being handled by the global error
  *               handler.
  * [in] error PSM error identifier

--- a/psm_diags.c
+++ b/psm_diags.c
@@ -287,7 +287,7 @@ memcpy_check_size (memcpy_fn_t fn, int *p, int *f, size_t n)
       return -1;
   }
   else {
-    void *src_p, *dst_p;
+    void *src_p = NULL, *dst_p = NULL;
     if (posix_memalign(&src_p, 64, size) != 0 ||
         posix_memalign(&dst_p, 64, size) != 0) {
       if (src_p) psmi_free(src_p);

--- a/psm_error.c
+++ b/psm_error.c
@@ -251,7 +251,7 @@ psmi_error_items[] = {
     { PSMI_NOLOG, "unknown 37" },
     { PSMI_NOLOG, "unknown 38" },
     { PSMI_NOLOG, "unknown 39" },
-    { PSMI_NOLOG, "Unknown/unresolved connection status (other errors occured)" }, /* PSM_EPID_UNKNOWN = 40 */
+    { PSMI_NOLOG, "Unknown/unresolved connection status (other errors occurred)" }, /* PSM_EPID_UNKNOWN = 40 */
     { PSMI_NOLOG, "Endpoint could not be reached" }, /* PSM_EPID_UNREACHABLE = 41 */
     { PSMI_NOLOG, "unknown 42" },
     { LOG_CRIT  , "Invalid node (mismatch in bit width 32/64 or byte order)" }, /* PSM_EPID_INVALID_NODE = 43 */

--- a/psm_mq.h
+++ b/psm_mq.h
@@ -552,7 +552,7 @@ psm_mq_test(psm_mq_req_t *request, psm_mq_status_t *status);
  *
  * [retval] PSM_OK The request could be successfully cancelled such that the
  *                preposted receive buffer could be removed from the preposted
- *                receive queue before a match occured. The associated @c
+ *                receive queue before a match occurred. The associated @c
  *                request remains unchanged and the user must still return
  *                the storage to the MQ library.
  *

--- a/ptl.h
+++ b/ptl.h
@@ -130,7 +130,7 @@ struct ptl_ctl
      *         ptl needs.
      * post 1: PTL marks error[i] as UNREACHABLE if PTL can't get to epid[i]
      * post 2: PTL marks error[i] as UNKNOWN for all epid[i] that couldn't be
-     *         connected before a timeout occured.
+     *         connected before a timeout occurred.
      * post 3: PTL returns OK iff all epids are either OK or UNREACHABLE
      * post 4: PTL defines content or epaddr[i] only if epaddr[i] is OK.
      */

--- a/ptl_am/am_reqrep_shmem.c
+++ b/ptl_am/am_reqrep_shmem.c
@@ -541,7 +541,7 @@ psmi_shm_attach(psm_ep_t ep, int *shmidx_o)
 	ips_mb();
 
 	ep->amsh_dirpage->is_init = 1;
-	_IPATH_PRDBG("Mapped and initalized shm object control page at %p,"
+	_IPATH_PRDBG("Mapped and initialized shm object control page at %p,"
                     "size=%ld, kcopy minor is %d (mode=%s)\n", mapptr,
 		    segsz, kcopy_minor,
 		    psmi_kassist_getmode(ep->psmi_kassist_mode));

--- a/ptl_ips/ips_spio.c
+++ b/ptl_ips/ips_spio.c
@@ -324,7 +324,7 @@ spio_update_shadow(struct ips_spio *ctrl, int index)
       }
       
       if (event_mask & IPATH_EVENT_LID_CHANGE) {
-	/* Display a warning that LID change has occured during the run. This
+	/* Display a warning that LID change has occurred during the run. This
 	 * is not supported in the current implementation and in general is
 	 * bad for the SM to re-assign LIDs during a run.
 	 */


### PR DESCRIPTION
This patch fixes the following -Werror=maybe-uninitialized errors:

psm_diags.c:294:10: error: 'dst_p' may be used uninitialized in this function [-Werror=maybe-uninitialized]
       if (dst_p) psmi_free(dst_p);
          ^
In file included from psm_user.h:54:0,
                 from psm_diags.c:35:
psm_utils.h:156:23: error: 'src_p' may be used uninitialized in this function [-Werror=maybe-uninitialized]
 #define psmi_free(sz) psmi_free_internal(sz)
                       ^
psm_diags.c:290:11: note: 'src_p' was declared here
     void *src_p, *dst_p;
           ^
If posix_memalign fails to return a value different than zero,
the pointers are never initialized.
I found this problem while updating the Debian package