### PR TITLE
Add missing extern keywords

### DIFF
--- a/psm_error.h
+++ b/psm_error.h
@@ -42,7 +42,7 @@
 #define PSMI_EP_NORETURN	    ((psm_ep_t) -2)
 #define PSMI_EP_LOGEVENT	    ((psm_ep_t) -3)
 
-psm_ep_errhandler_t psmi_errhandler_global;
+extern psm_ep_errhandler_t psmi_errhandler_global;
 
 psm_error_t psmi_handle_error(psm_ep_t ep, psm_error_t error, 
 			      const char *buf, ...)

--- a/psm_user.h
+++ b/psm_user.h
@@ -100,7 +100,7 @@ psm_error_t psmi_mq_wait_internal(psm_mq_req_t *ireq);
 #endif
 
 #ifdef PSMI_PLOCK_IS_SPINLOCK
-  psmi_spinlock_t  psmi_progress_lock;
+  extern psmi_spinlock_t  psmi_progress_lock;
   #define PSMI_PLOCK_INIT()   psmi_spin_init(&psmi_progress_lock)
   #define PSMI_PLOCK_TRY()    psmi_spin_trylock(&psmi_progress_lock)
   #define PSMI_PLOCK()	      psmi_spin_lock(&psmi_progress_lock)
@@ -109,8 +109,8 @@ psm_error_t psmi_mq_wait_internal(psm_mq_req_t *ireq);
   #define PSMI_PUNLOCK_ASSERT()
   #define PSMI_PLOCK_DISABLED  0
 #elif defined(PSMI_PLOCK_IS_MUTEXLOCK_DEBUG) 
-  pthread_mutex_t  psmi_progress_lock;
-  pthread_t	   psmi_progress_lock_owner;
+  extern pthread_mutex_t  psmi_progress_lock;
+  extern pthread_t	   psmi_progress_lock_owner;
   #define PSMI_PLOCK_NO_OWNER	((pthread_t)(-1))
 
   PSMI_ALWAYS_INLINE(

--- a/psm_utils.h
+++ b/psm_utils.h
@@ -254,7 +254,7 @@ int	psmi_diags(void);
  * Fault injection
  */
 struct psmi_faultinj_spec;
-int    psmi_faultinj_enabled; /* use macro to test */
+extern int    psmi_faultinj_enabled; /* use macro to test */
 #if 1 /* possible to disable at compile time */
 #define PSMI_FAULTINJ_ENABLED()	(!!psmi_faultinj_enabled)
 #else

--- a/ptl_am/ptl_fwd.h
+++ b/ptl_am/ptl_fwd.h
@@ -47,7 +47,7 @@
 #endif
 
 /* Symbol in am ptl */
-struct ptl_ctl_init psmi_ptl_amsh;
+extern struct ptl_ctl_init psmi_ptl_amsh;
 
 /* Special non-ptl function exposed to pre-attach to shm segment */
 psm_error_t psmi_shm_attach(psm_ep_t ep, int *shmidx_o);

--- a/ptl_ips/ptl_fwd.h
+++ b/ptl_ips/ptl_fwd.h
@@ -38,5 +38,5 @@
 typedef struct ptl_epaddr ips_epaddr_t;
 
 /* Symbol in ips ptl */
-struct ptl_ctl_init psmi_ptl_ips;
+extern struct ptl_ctl_init psmi_ptl_ips;
 #endif /* _PTL_FWD_IPS_H */

--- a/ptl_self/ptl_fwd.h
+++ b/ptl_self/ptl_fwd.h
@@ -35,7 +35,7 @@
 #define _PTL_FWD_SELF_H
 
 /* Symbol in am ptl */
-struct ptl_ctl_init psmi_ptl_self;
+extern struct ptl_ctl_init psmi_ptl_self;
 
 #endif
 


### PR DESCRIPTION
Starting from the upcoming GCC release 10, the default of -fcommon option will change to -fno-common:
In C, global variables with multiple tentative definitions will result in linker errors.
Global variable accesses are also more efficient on various targets.

This fixes compilations errors with -fno-common enabled

Signed-off-by: Nicolas Morey-Chaisemartin <nmoreychaisemartin@suse.com>